### PR TITLE
Address issue #322

### DIFF
--- a/examples/get-all-users.ts
+++ b/examples/get-all-users.ts
@@ -32,11 +32,14 @@ const User = t.type(
 interface Payload extends t.TypeOf<typeof Payload> {}
 const Payload = t.type(
   {
-    page: t.number,
-    per_page: t.number,
-    total: t.number,
-    total_pages: t.number,
-    data: t.array(User)
+    status: t.literal(200),
+    data: t.type({
+      page: t.number,
+      per_page: t.number,
+      total: t.number,
+      total_pages: t.number,
+      data: t.array(User)
+    })
   },
   'API Payload'
 );
@@ -53,7 +56,7 @@ const getUsersPaginated = (page: number): Req<Payload> =>
   );
 
 const getTheRest = (resp: Resp<Payload>, users: User[] = []): Req<User[]> => {
-  const {data, page, total_pages} = resp.data; // eslint-disable-line camelcase
+  const {data, page, total_pages} = resp.data.data; // eslint-disable-line camelcase
   const total = users.concat(data);
 
   return page === total_pages // eslint-disable-line camelcase

--- a/src/combinators/decoder.ts
+++ b/src/combinators/decoder.ts
@@ -35,9 +35,9 @@ export interface Decoder<A> extends GenericDecoder<Error, A> {}
  * It automatically sets "JSON" request header's
  *
  * @category combinators
- * @since 3.0.0
+ * @since 4.0.0
  */
-export function withDecoder<A, B>(
+export function withDecoder<A, B extends {data: unknown; status: number}>(
   decoder: Decoder<B>
 ): (req: Req<A>) => Req<B> {
   return req =>
@@ -75,9 +75,12 @@ export function toDecoder<E, A>(
   return pipe(dec, mapLeft(onLeft));
 }
 
-function parseResponse<A>({data}: Resp<A>): E.Either<Error, unknown> {
+function parseResponse<A>({
+  data,
+  response: {status}
+}: Resp<A>): E.Either<Error, unknown> {
   if (typeof data === 'object') {
-    return E.right(data);
+    return E.right({data, status});
   }
 
   const asString = String(data);

--- a/src/combinators/success-statuses.ts
+++ b/src/combinators/success-statuses.ts
@@ -1,0 +1,52 @@
+/**
+ * `SuccessStatuses` combinator: checks `Resp['status']` of a `Req<A>` and returns a `Req<A>`.
+ *
+ * @since 4.0.0
+ */
+
+import * as E from 'fp-ts/lib/Either';
+import * as RTE from 'fp-ts/lib/ReaderTaskEither';
+import {pipe} from 'fp-ts/lib/pipeable';
+import {Err, Req, Resp, toResponseError} from '../index';
+
+/**
+ * Checks `status` to the `Resp<A>` of a `Req`.
+ *
+ * It returns a `Left<ResponseError>` in case the response is not ok and the
+ * status is not included in the `successResponseStatuses` array.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export function withSuccessStatuses<A>(
+  successResponseStatuses: number[]
+): (req: Req<A>) => Req<A> {
+  return req =>
+    pipe(
+      req,
+      RTE.chain(resp =>
+        RTE.fromEither(
+          pipe(
+            parseResponse(resp, successResponseStatuses),
+            E.bimap(
+              (e): Err => toResponseError(e, resp.response),
+              data => ({...resp, data})
+            )
+          )
+        )
+      )
+    );
+}
+
+function parseResponse<A>(
+  {data, response}: Resp<A>,
+  successStatuses: number[]
+): E.Either<Error, A> {
+  const {status} = response;
+
+  if (response.ok || successStatuses.includes(status)) {
+    return E.right(data);
+  }
+
+  return E.left(new Error(`Request responded with status code ${status}`));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,13 +113,6 @@ export const request: Req<string> = input => () => {
   return fetch(...reqInput)
     .then(
       async response => {
-        if (!response.ok) {
-          throw toResponseError(
-            new Error(`Request responded with status code ${response.status}`),
-            response
-          );
-        }
-
         const data = await response.text();
 
         return E.right({response, data});

--- a/test/decoder.spec.ts
+++ b/test/decoder.spec.ts
@@ -11,7 +11,7 @@ afterEach(() => {
   fetchMock.reset();
 });
 
-test('withDecoder() should decodes `Resp` with provided decoder', async () => {
+test('withDecoder() should decode `Resp` with provided decoder', async () => {
   const response = new Response('{"id": 1234, "name": "foo bar"}');
   fetchMock.mock('http://localhost/api/resources', response);
 
@@ -27,7 +27,7 @@ test('withDecoder() should decodes `Resp` with provided decoder', async () => {
   );
 });
 
-test('withDecoder() should decodes `Resp` with provided decoder - response data is empty string', async () => {
+test('withDecoder() should decode `Resp` with provided decoder - response data is empty string', async () => {
   const response = new Response('');
   fetchMock.mock('http://localhost/api/resources', response);
 
@@ -61,7 +61,10 @@ test('withDecoder() should decodes `Resp` with provided decoder - response data 
   expect(result).toEqual(
     right({
       response,
-      data: {id: 5678, name: 'THIS IS BAAAZ!'}
+      data: {
+        status: 200,
+        data: {id: 5678, name: 'THIS IS BAAAZ!'}
+      }
     })
   );
 });
@@ -129,19 +132,24 @@ test('toDecoder() should convert a `GenericDecoder` into a `Decoder`', () => {
     e => new Error(failure(e).join('\n'))
   );
 
-  expect(d({id: 1234, name: 'foo bar', active: true})).toEqual(
+  expect(
+    d({status: 200, data: {id: 1234, name: 'foo bar', active: true}})
+  ).toEqual(
     right({
-      id: 1234,
-      name: 'foo bar',
-      active: true
+      status: 200,
+      data: {
+        id: 1234,
+        name: 'foo bar',
+        active: true
+      }
     })
   );
 
-  expect(d({id: false})).toEqual(
+  expect(d({status: 200, data: {id: false}})).toEqual(
     left(
       new Error(
-        `Invalid value false supplied to : Payload/id: number
-Invalid value undefined supplied to : Payload/name: string`
+        `Invalid value false supplied to : Payload/data: { id: number, name: string }/id: number
+Invalid value undefined supplied to : Payload/data: { id: number, name: string }/name: string`
       )
     )
   );
@@ -149,8 +157,8 @@ Invalid value undefined supplied to : Payload/name: string`
 
 // --- Helpers
 interface Payload {
-  id: number;
-  name: string;
+  status: 200;
+  data: {id: number; name: string};
 }
 
 const decoderOK: Decoder<Payload> = u => {
@@ -162,8 +170,11 @@ const decoderKO: Decoder<Payload> = _ => left(new Error('decoding failed'));
 
 const iotsPayload = t.type(
   {
-    id: t.number,
-    name: t.string
+    status: t.literal(200),
+    data: t.type({
+      id: t.number,
+      name: t.string
+    })
   },
   'Payload'
 );

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -64,24 +64,6 @@ test('request() should return a left `RequestError` when request fails', async (
   );
 });
 
-test('request() should return a left `ResponseError` when response status is not ok', async () => {
-  const response = new Response('a list of resources', {
-    status: 503
-  });
-
-  fetchMock.mock('http://localhost/api/resources', response);
-
-  const r = await appy.request('http://localhost/api/resources')();
-
-  expect(r).toEqual(
-    left({
-      type: 'ResponseError',
-      response,
-      error: new Error(`Request responded with status code 503`)
-    })
-  );
-});
-
 test('get() should run a GET request', async () => {
   const response = new Response('a list of resources');
 

--- a/test/success-statuses.spec.ts
+++ b/test/success-statuses.spec.ts
@@ -1,0 +1,45 @@
+import fetchMock from 'fetch-mock';
+import {right, left} from 'fp-ts/lib/Either';
+import {withSuccessStatuses} from '../src/combinators/success-statuses';
+import * as appy from '../src/index';
+
+afterEach(() => {
+  fetchMock.reset();
+});
+
+test('withSuccessStatuses() should let `Resp` with allowed status to go through', async () => {
+  const response = new Response('{"errors": [{"title": "InvalidId"}]}', {
+    status: 400
+  });
+  fetchMock.mock('http://localhost/api/resources', response);
+
+  const request = withSuccessStatuses([400])(appy.get);
+
+  const result = await request('http://localhost/api/resources')();
+
+  expect(result).toEqual(
+    right({
+      response,
+      data: '{"errors": [{"title": "InvalidId"}]}'
+    })
+  );
+});
+
+test('withSuccessStatuses() should fail if response status is not allowed', async () => {
+  const response = new Response('{"errors": [{"title": "InvalidId"}]}', {
+    status: 400
+  });
+  fetchMock.mock('http://localhost/api/resources', response);
+
+  const request = withSuccessStatuses([])(appy.get);
+
+  const result = await request('http://localhost/api/resources')();
+
+  expect(result).toEqual(
+    left({
+      type: 'ResponseError',
+      error: new Error('Request responded with status code 400'),
+      response
+    })
+  );
+});


### PR DESCRIPTION
This PR:

- Modifies the `request` function to no longer throw on non-ok responses
- Implements a new combinator to control which response statuses are considered successful
- Updates `withDecoder` to require a tagged union type of decoder as its input

Note that these changes are intentionally breaking the current API.

resolves #322
