### PR TITLE
Fix ReqInput merging strategy in combinators

### DIFF
--- a/docs/modules/combinators/abort.ts.md
+++ b/docs/modules/combinators/abort.ts.md
@@ -19,6 +19,23 @@ We suggest you to use a polyfill (check out the [`_setup.ts`](https://github.com
 - [abort-controller](https://www.npmjs.com/package/abort-controller)
 - [abortcontroller-polyfill](https://www.npmjs.com/package/abortcontroller-polyfill)
 
+**Warning:** the merging logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).
+
+This leads to a "weird" behavior for which the signal provided when `Req` is run wins over the one set with the combinator.
+
+So, for example, if we have:
+
+```ts
+const controller1 = new AbortController()
+const controller2 = new AbortController()
+
+const request = pipe(appy.get, withCancel(controller1))
+
+request(['http://some.endpoint', { signal: controller2.signal }])
+```
+
+the `request` will be aborted only when **`controller2`** calls the `abort()` method.
+
 Added in v3.1.0
 
 ---

--- a/docs/modules/combinators/body.ts.md
+++ b/docs/modules/combinators/body.ts.md
@@ -8,6 +8,23 @@ parent: Modules
 
 `body` combinator: sets body on a `Req` and returns a `Req`.
 
+**Warning:** the merging logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).
+
+This leads to a "weird" behavior for which the body provided when `Req` is run wins over the one set with the combinator.
+
+So, for example, if we have:
+
+```ts
+const body1 = { id: 123, name: 'foo bar' }
+const body2 = { id: 456, name: 'baz aaa' }
+
+const request = pipe(appy.post, withBody(body1))
+
+request(['http://some.endpoint', { body: JSON.stringify(body2) }])
+```
+
+when `request` is ran the underlying `fetch` call will be made with a `"{'id': 456, 'name': 'baz aaa'}"` body.
+
 Added in v3.0.0
 
 ---

--- a/docs/modules/combinators/headers.ts.md
+++ b/docs/modules/combinators/headers.ts.md
@@ -8,6 +8,20 @@ parent: Modules
 
 `Headers` combinator: sets headers on a `Req` and returns a `Req`.
 
+**Warning:** the merging logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).
+
+This leads to a "weird" behavior for which the headers provided when `Req` is run win over the ones set with the combinator.
+
+So, for example, if we have:
+
+```ts
+const request = pipe(appy.get, withHeaders({ 'X-Foo': 'bar' }), withHeaders({ 'X-Foo': 'baz' }))
+
+request(['http://some.endpoint', { headers: { 'X-Foo': 'foo' } }])
+```
+
+when `request` is ran the underlying `fetch` call will be made with a `X-Foo = 'foo'` header.
+
 Added in v3.0.0
 
 ---

--- a/docs/modules/combinators/url-params.ts.md
+++ b/docs/modules/combinators/url-params.ts.md
@@ -8,6 +8,20 @@ parent: Modules
 
 `URLSearchParams` combinator: sets query parameters to `Req`'s url and returns a `Req`.
 
+**Warning:** the merging logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).
+
+This leads to a "weird" behavior for which the url's parameters provided when `Req` is run win over the ones set with the combinator.
+
+So, for example, if we have:
+
+```ts
+const request = pipe(appy.get, withUrlParams({ foo: 'bar', baz: String(null) }))
+
+request('http://some.endpoint?foo=aaa')
+```
+
+the url of `fetch` call will be `http://some.endpoint?foo=aaa&baz=null`.
+
 Added in v3.0.0
 
 ---

--- a/src/combinators/body.ts
+++ b/src/combinators/body.ts
@@ -1,6 +1,21 @@
 /**
  * `body` combinator: sets body on a `Req` and returns a `Req`.
  *
+ * **Warning:** the merging logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).
+ *
+ * This leads to a "weird" behavior for which the body provided when `Req` is run wins over the one set with the combinator.
+ *
+ * So, for example, if we have:
+ * ```ts
+ * const body1 = {id: 123, name: 'foo bar'};
+ * const body2 = {id: 456, name: 'baz aaa'};
+ *
+ * const request = pipe(appy.post, withBody(body1));
+ *
+ * request(['http://some.endpoint', {body: JSON.stringify(body2)}])
+ * ```
+ * when `request` is ran the underlying `fetch` call will be made with a `"{'id': 456, 'name': 'baz aaa'}"` body.
+ *
  * @since 3.0.0
  */
 
@@ -27,7 +42,12 @@ function setBody<A>(req: Req<A>): (body: BodyInit) => Req<A> {
       RTE.local(input =>
         pipe(
           normalizeReqInput(input),
-          TU.mapLeft(init => ({...init, body}))
+          // The "weird" merging is due to the mix of the contravariant nature of `Reader`
+          // and the function composition at the base of "combinators".
+          // Because combinators are applied from right to left, the merging has to be "reversed".
+          // This leads to another "weird" behavior for which the body provided when `Req` is run
+          // wins over the one set with the combinator.
+          TU.mapLeft(init => Object.assign({}, {body}, init))
         )
       )
     );

--- a/src/combinators/headers.ts
+++ b/src/combinators/headers.ts
@@ -17,7 +17,7 @@
  */
 
 import * as RTE from 'fp-ts/lib/ReaderTaskEither';
-import * as Rec from 'fp-ts/lib/Record';
+import {getMonoid} from 'fp-ts/lib/Record';
 import {getLastSemigroup} from 'fp-ts/lib/Semigroup';
 import * as TU from 'fp-ts/lib/Tuple';
 import {pipe} from 'fp-ts/lib/pipeable';
@@ -25,7 +25,7 @@ import {Req, normalizeReqInput} from '../index';
 
 type Hs = Record<string, string>;
 
-const RML = Rec.getMonoid(getLastSemigroup<string>());
+const RML = getMonoid(getLastSemigroup<string>());
 
 /**
  * Merges provided `Headers` with `Req` ones and returns the updated `Req`.

--- a/src/combinators/url-params.ts
+++ b/src/combinators/url-params.ts
@@ -1,6 +1,18 @@
 /**
  * `URLSearchParams` combinator: sets query parameters to `Req`'s url and returns a `Req`.
  *
+ * **Warning:** the merging logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).
+ *
+ * This leads to a "weird" behavior for which the url's parameters provided when `Req` is run win over the ones set with the combinator.
+ *
+ * So, for example, if we have:
+ * ```ts
+ * const request = pipe(appy.get, withUrlParams({foo: 'bar', baz: String(null)}));
+ *
+ * request('http://some.endpoint?foo=aaa')
+ * ```
+ * the url of `fetch` call will be `http://some.endpoint?foo=aaa&baz=null`.
+ *
  * @since 3.0.0
  */
 
@@ -31,7 +43,12 @@ function setURLParams(
       normalizeReqInput(input),
       TU.map(info => {
         const url = getURL(info);
-        const p = merge(url.searchParams, urlParams);
+        // The "weird" merging is due to the mix of the contravariant nature of `Reader`
+        // and the function composition at the base of "combinators".
+        // Because combinators are applied from right to left, the merging has to be "reversed".
+        // This leads to another "weird" behavior for which the url's params provided when `Req` is run
+        // win over the ones set with the combinator.
+        const p = merge(urlParams, url.searchParams);
 
         return setParams(p, url).toString();
       })

--- a/test/abort.spec.ts
+++ b/test/abort.spec.ts
@@ -1,5 +1,6 @@
 import fetchMock from 'fetch-mock';
 import {left, right} from 'fp-ts/lib/Either';
+import {pipe} from 'fp-ts/lib/pipeable';
 import {withCancel, withTimeout} from '../src/combinators/abort';
 import * as appy from '../src/index';
 
@@ -27,6 +28,55 @@ test('withCancel() should set signal on `Req` and make request abortable', async
   );
 });
 
+test('withCancel() should set signal on `Req` and make request abortable - multiple calls', async () => {
+  fetchMock.mock('http://localhost/api/resources', 200);
+
+  const controller1 = new AbortController();
+  const controller2 = new AbortController();
+
+  const request = pipe(
+    appy.request,
+    withCancel(controller1),
+    withCancel(controller2)
+  );
+
+  controller2.abort();
+
+  const result = await request('http://localhost/api/resources')();
+
+  expect(result).toEqual(
+    left({
+      type: 'RequestError',
+      error: new AbortError(),
+      input: ['http://localhost/api/resources', {signal: controller2.signal}]
+    })
+  );
+});
+
+test('withCancel() should merge provided signal with `Req` one - but `Req` wins', async () => {
+  fetchMock.mock('http://localhost/api/resources', 200);
+
+  const controller1 = new AbortController();
+  const controller2 = new AbortController();
+
+  const request = withCancel(controller1)(appy.request);
+
+  controller2.abort();
+
+  const result = await request([
+    'http://localhost/api/resources',
+    {signal: controller2.signal}
+  ])();
+
+  expect(result).toEqual(
+    left({
+      type: 'RequestError',
+      error: new AbortError(),
+      input: ['http://localhost/api/resources', {signal: controller2.signal}]
+    })
+  );
+});
+
 test('withTimeout() should succeed if we get a response within provided milliseconds', async () => {
   const response = new Response('a list of resources', {
     status: 200,
@@ -42,10 +92,44 @@ test('withTimeout() should succeed if we get a response within provided millisec
   expect(result).toEqual(right({response, data: 'a list of resources'}));
 });
 
+test('withTimeout() should succeed if we get a response within provided milliseconds - multiple calls', async () => {
+  const response = new Response('a list of resources', {
+    status: 200,
+    headers: {}
+  });
+
+  fetchMock.mock('http://localhost/api/resources', response, {delay: 500});
+
+  const request = pipe(appy.request, withTimeout(250), withTimeout(1000));
+
+  const result = await request('http://localhost/api/resources')();
+
+  expect(result).toEqual(right({response, data: 'a list of resources'}));
+});
+
 test('withTimeout() should fail if we do not get a response within provided milliseconds', async () => {
   fetchMock.mock('http://localhost/api/resources', 200, {delay: 1000});
 
   const request = withTimeout(500)(appy.request);
+
+  const result = await request('http://localhost/api/resources')();
+
+  expect(result).toEqual(
+    left({
+      type: 'RequestError',
+      error: new AbortError(),
+      input: [
+        'http://localhost/api/resources',
+        {signal: new AbortController().signal}
+      ]
+    })
+  );
+});
+
+test('withTimeout() should fail if we do not get a response within provided milliseconds - multiple calls', async () => {
+  fetchMock.mock('http://localhost/api/resources', 200, {delay: 1000});
+
+  const request = pipe(appy.request, withTimeout(1500), withTimeout(500));
 
   const result = await request('http://localhost/api/resources')();
 

--- a/test/body.spec.ts
+++ b/test/body.spec.ts
@@ -2,7 +2,7 @@ import fetchMock from 'fetch-mock';
 import {left, mapLeft} from 'fp-ts/lib/Either';
 import {pipe} from 'fp-ts/lib/pipeable';
 import {withBody} from '../src/combinators/body';
-import * as appy from '../src/index';
+import {post} from '../src/index';
 
 afterEach(() => {
   fetchMock.reset();
@@ -12,7 +12,7 @@ test('withBody() should set provided JSON body on `Req` (stringified)', async ()
   fetchMock.mock('http://localhost/api/resources', 200);
 
   const body = {id: 123, name: 'foo bar'};
-  const request = withBody(body)(appy.post);
+  const request = withBody(body)(post);
 
   await request('http://localhost/api/resources')();
 
@@ -27,7 +27,7 @@ test('withBody() should set provided JSON body on `Req` (stringified) - multiple
 
   const body1 = {id: 123, name: 'foo bar'};
   const body2 = {id: 456, name: 'baz aaa'};
-  const request = pipe(appy.post, withBody(body1), withBody(body2));
+  const request = pipe(post, withBody(body1), withBody(body2));
 
   await request('http://localhost/api/resources')();
 
@@ -42,7 +42,7 @@ test('withBody() should set provided JSON body on `Req` (stringified) - but `Req
 
   const body1 = {id: 123, name: 'foo bar'};
   const body2 = {id: 456, name: 'baz aaa'};
-  const request = withBody(body1)(appy.post);
+  const request = withBody(body1)(post);
 
   await request([
     'http://localhost/api/resources',
@@ -60,7 +60,7 @@ test('withBody() should fail if provided JSON body throws error when stringified
 
   const body = {} as any;
   body.itself = body;
-  const request = withBody(body)(appy.post);
+  const request = withBody(body)(post);
 
   const result = await request('http://localhost/api/resources')();
 
@@ -90,7 +90,7 @@ test('withBody() should set provided body on `Req` - string', async () => {
   fetchMock.mock('http://localhost/api/resources', 200);
 
   const body = '{id: 123, name: "foo bar"}';
-  const request = withBody(body)(appy.post);
+  const request = withBody(body)(post);
 
   await request('http://localhost/api/resources')();
 
@@ -104,7 +104,7 @@ test('withBody() should set provided body on `Req` - Blob', async () => {
   fetchMock.mock('http://localhost/api/resources', 200);
 
   const body = new Blob(['{id: 123, name: "foo bar"}']);
-  const request = withBody(body)(appy.post);
+  const request = withBody(body)(post);
 
   await request('http://localhost/api/resources')();
 
@@ -121,7 +121,7 @@ test('withBody() should set provided body on `Req` - FormData', async () => {
   body.set('id', '123');
   body.set('name', 'foo bar');
 
-  const request = withBody(body)(appy.post);
+  const request = withBody(body)(post);
 
   await request('http://localhost/api/resources')();
 
@@ -138,7 +138,7 @@ test('withBody() should set provided body on `Req` - URLSearchParams', async () 
   body.set('id', '123');
   body.set('name', 'foo bar');
 
-  const request = withBody(body)(appy.post);
+  const request = withBody(body)(post);
 
   await request('http://localhost/api/resources')();
 

--- a/test/body.spec.ts
+++ b/test/body.spec.ts
@@ -22,6 +22,39 @@ test('withBody() should set provided JSON body on `Req` (stringified)', async ()
   });
 });
 
+test('withBody() should set provided JSON body on `Req` (stringified) - multiple calls', async () => {
+  fetchMock.mock('http://localhost/api/resources', 200);
+
+  const body1 = {id: 123, name: 'foo bar'};
+  const body2 = {id: 456, name: 'baz aaa'};
+  const request = pipe(appy.post, withBody(body1), withBody(body2));
+
+  await request('http://localhost/api/resources')();
+
+  expect(fetchMock.lastOptions()).toEqual({
+    body: JSON.stringify(body2),
+    method: 'POST'
+  });
+});
+
+test('withBody() should set provided JSON body on `Req` (stringified) - but `Req` wins', async () => {
+  fetchMock.mock('http://localhost/api/resources', 200);
+
+  const body1 = {id: 123, name: 'foo bar'};
+  const body2 = {id: 456, name: 'baz aaa'};
+  const request = withBody(body1)(appy.post);
+
+  await request([
+    'http://localhost/api/resources',
+    {body: JSON.stringify(body2)}
+  ])();
+
+  expect(fetchMock.lastOptions()).toEqual({
+    body: JSON.stringify(body2),
+    method: 'POST'
+  });
+});
+
 test('withBody() should fail if provided JSON body throws error when stringified', async () => {
   fetchMock.mock('http://localhost/api/resources', 200);
 

--- a/test/url-params.spec.ts
+++ b/test/url-params.spec.ts
@@ -23,6 +23,23 @@ test('withUrlParams() should add provided query params to `Req` input', async ()
   );
 });
 
+test('withUrlParams() should add provided query params to `Req` input - multiple calls', async () => {
+  fetchMock.mock('begin:http://localhost/api/resources', 200);
+
+  const request = withUrlParams({
+    foo: 'bar',
+    baz: String(null),
+    asdf: String(true),
+    ghjk: String(1234)
+  })(appy.request);
+
+  await request('http://localhost/api/resources')();
+
+  expect(fetchMock.lastUrl()).toBe(
+    'http://localhost/api/resources?foo=bar&baz=null&asdf=true&ghjk=1234'
+  );
+});
+
 test('withUrlParams() should merge provided query params with `Req` input ones', async () => {
   fetchMock.mock('begin:http://localhost/api/resources', 200);
 

--- a/test/url-params.spec.ts
+++ b/test/url-params.spec.ts
@@ -1,4 +1,5 @@
 import fetchMock from 'fetch-mock';
+import {pipe} from 'fp-ts/lib/pipeable';
 import {withUrlParams} from '../src/combinators/url-params';
 import * as appy from '../src/index';
 
@@ -26,21 +27,30 @@ test('withUrlParams() should add provided query params to `Req` input', async ()
 test('withUrlParams() should add provided query params to `Req` input - multiple calls', async () => {
   fetchMock.mock('begin:http://localhost/api/resources', 200);
 
-  const request = withUrlParams({
-    foo: 'bar',
-    baz: String(null),
-    asdf: String(true),
-    ghjk: String(1234)
-  })(appy.request);
+  const request = pipe(
+    appy.request,
+    withUrlParams({
+      foo: 'bar',
+      baz: String(null),
+      asdf: String(true),
+      ghjk: String(1234)
+    }),
+    withUrlParams({
+      foo: 'baz',
+      baz: String(null),
+      asdf: String(false),
+      ghjk: String(5678)
+    })
+  );
 
   await request('http://localhost/api/resources')();
 
   expect(fetchMock.lastUrl()).toBe(
-    'http://localhost/api/resources?foo=bar&baz=null&asdf=true&ghjk=1234'
+    'http://localhost/api/resources?foo=baz&baz=null&asdf=false&ghjk=5678'
   );
 });
 
-test('withUrlParams() should merge provided query params with `Req` input ones', async () => {
+test('withUrlParams() should merge provided query params with `Req` input ones - but `Req` wins', async () => {
   fetchMock.mock('begin:http://localhost/api/resources', 200);
 
   const request = withUrlParams({
@@ -53,6 +63,6 @@ test('withUrlParams() should merge provided query params with `Req` input ones',
   await request('http://localhost/api/resources?foo=BARBAR&zxcv=42&baz=true')();
 
   expect(fetchMock.lastUrl()).toBe(
-    'http://localhost/api/resources?foo=bar&zxcv=42&baz=null&asdf=true&ghjk=1234'
+    'http://localhost/api/resources?foo=BARBAR&baz=true&asdf=true&ghjk=1234&zxcv=42'
   );
 });


### PR DESCRIPTION
This PR:

- fixes the merging strategy of `ReqInput` for consecutive calls to the same combinator 

**Notes**
The logic had to be "reversed" because of the contravariant nature of `Reader` and because the execution of combinators is from right to left (_function composition_).

This leads to a "weird" behavior for which the data provided when `Req` is run win over the ones set with the combinators.
