### PR TITLE
Remove Content-Type header from withDecoder 

### DIFF
--- a/src/combinators/decoder.ts
+++ b/src/combinators/decoder.ts
@@ -43,10 +43,7 @@ export function withDecoder<A, B>(
   return req =>
     pipe(
       req,
-      withHeaders({
-        Accept: 'application/json',
-        'Content-type': 'application/json'
-      }),
+      withHeaders({Accept: 'application/json'}),
       RTE.chain(resp =>
         RTE.fromEither(
           pipe(


### PR DESCRIPTION
This PR:

- removes useless/error-prone `Content-Type` header from `withDecoder` combinator implementation

resolves #328
