### PR TITLE
Fix response field of ResponseError of withDecoder combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[internal]` Response in ResponseError of withDecoder combinator cannot be consumed ([#360](https://github.com/contactlab/appy/issues/360))
 
+**Dependencies:**
+
+- [Security] Bump node-notifier from 8.0.0 to 8.0.1 (#347)
+
 ## [4.0.0](https://github.com/contactlab/appy/releases/tag/4.0.0)
 
 **Breaking:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.1](https://github.com/contactlab/appy/releases/tag/4.0.1)
+
+**Bug Fix:**
+
+- `[internal]` Response in ResponseError of withDecoder combinator cannot be consumed ([#360](https://github.com/contactlab/appy/issues/360))
+
 ## [4.0.0](https://github.com/contactlab/appy/releases/tag/4.0.0)
 
 **Breaking:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ nav_order: 2
 
 # Changelog
 
+## [4.0.1](https://github.com/contactlab/appy/releases/tag/4.0.1)
+
+**Bug Fix:**
+
+- `[internal]` Response in ResponseError of withDecoder combinator cannot be consumed ([#360](https://github.com/contactlab/appy/issues/360))
+
 ## [4.0.0](https://github.com/contactlab/appy/releases/tag/4.0.0)
 
 **Breaking:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ nav_order: 2
 
 - `[internal]` Response in ResponseError of withDecoder combinator cannot be consumed ([#360](https://github.com/contactlab/appy/issues/360))
 
+**Dependencies:**
+
+- [Security] Bump node-notifier from 8.0.0 to 8.0.1 (#347)
+
 ## [4.0.0](https://github.com/contactlab/appy/releases/tag/4.0.0)
 
 **Breaking:**

--- a/docs/modules/response.ts.md
+++ b/docs/modules/response.ts.md
@@ -1,0 +1,36 @@
+---
+title: response.ts
+nav_order: 9
+parent: Modules
+---
+
+## response overview
+
+`Response` module: exports utilites to work with `Response` objects.
+
+Added in v4.0.1
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [helpers](#helpers)
+  - [cloneResponse](#cloneresponse)
+
+---
+
+# helpers
+
+## cloneResponse
+
+Clones a `Response` object with the provided content as body.
+
+**Warning:** if the content is a plain object and _stringifying_ it fails, the cloned `Response`'s body will be set to `null` (the default value).
+
+**Signature**
+
+```ts
+export declare function cloneResponse<A>(from: Response, content: A): Response
+```
+
+Added in v4.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/appy",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/appy",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A functional wrapper around Fetch API",
   "main": "./index.js",
   "module": "./_es6/index.js",

--- a/src/combinators/decoder.ts
+++ b/src/combinators/decoder.ts
@@ -9,6 +9,7 @@ import {ReaderEither, mapLeft} from 'fp-ts/ReaderEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
 import {pipe} from 'fp-ts/function';
 import {Err, Req, Resp, toResponseError} from '../request';
+import {cloneResponse} from '../response';
 import {withHeaders} from './headers';
 
 /**
@@ -50,7 +51,8 @@ export function withDecoder<A, B>(
             parseResponse(resp),
             E.chain(decoder),
             E.bimap(
-              (e): Err => toResponseError(e, resp.response),
+              (e): Err =>
+                toResponseError(e, cloneResponse(resp.response, resp.data)),
               data => ({...resp, data})
             )
           )

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,0 +1,31 @@
+/**
+ * `Response` module: exports utilites to work with `Response` objects.
+ *
+ * @since 4.0.1
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response|Response}
+ */
+
+/**
+ * Clones a `Response` object with the provided content as body.
+ *
+ * **Warning:** if the content is a plain object and _stringifying_ it fails, the cloned `Response`'s body will be set to `null` (the default value).
+ *
+ * @category helpers
+ * @since 4.0.1
+ */
+export function cloneResponse<A>(from: Response, content: A): Response {
+  let body: BodyInit | null;
+
+  try {
+    body =
+      typeof content === 'object' ? JSON.stringify(content) : String(content);
+  } catch (e) {
+    body = null;
+  }
+
+  return new Response(body, {
+    headers: from.headers,
+    status: from.status,
+    statusText: from.statusText
+  });
+}

--- a/test/response.spec.ts
+++ b/test/response.spec.ts
@@ -1,0 +1,89 @@
+import {cloneResponse} from '../src/response';
+
+test('cloneResponse() should clone `Response` setting provided content as body', async () => {
+  // --- string
+  const responseStr = cloneResponse(
+    new Response('foo bar baz', {
+      headers: {'Content-Type': 'text/plain'},
+      status: 200,
+      statusText: 'OK'
+    }),
+    'foo bar baz'
+  );
+
+  const txtStr = await responseStr.text();
+
+  expect(txtStr).toBe('foo bar baz');
+  expect(responseStr.headers).toEqual(
+    new Headers({'Content-Type': 'text/plain'})
+  );
+  expect(responseStr.status).toBe(200);
+  expect(responseStr.statusText).toBe('OK');
+
+  // --- number
+  const responseNum = cloneResponse(
+    new Response('foo bar baz', {
+      headers: new Headers({'Content-Type': 'text/plain'}),
+      status: 200,
+      statusText: 'OK'
+    }),
+    100
+  );
+
+  const txtNum = await responseNum.text();
+
+  expect(txtNum).toBe('100');
+  expect(responseNum.headers).toEqual(
+    new Headers({'Content-Type': 'text/plain'})
+  );
+  expect(responseNum.status).toBe(200);
+  expect(responseNum.statusText).toBe('OK');
+
+  // --- boolean
+  const responseBool = cloneResponse(
+    new Response('foo bar baz', {
+      status: 204,
+      statusText: 'no content'
+    }),
+    true
+  );
+
+  const txtBool = await responseBool.text();
+
+  expect(txtBool).toBe('true');
+  expect(responseBool.status).toBe(204);
+  expect(responseBool.statusText).toBe('no content');
+
+  // --- JSON
+  const responseJSON = cloneResponse(
+    new Response('{"foo": "bar"}', {
+      status: 500,
+      statusText: 'Internal server error'
+    }),
+    {foo: 'bar'}
+  );
+
+  const json = await responseJSON.json();
+
+  expect(json).toEqual({foo: 'bar'});
+  expect(responseJSON.status).toBe(500);
+  expect(responseJSON.statusText).toBe('Internal server error');
+});
+
+test('cloneResponse() should return an empty `Response` when provided content cannot be stringified', async () => {
+  const response = cloneResponse(
+    new Response('{"foo": "bar"}', {
+      headers: {'Content-Type': 'text/plain'},
+      status: 500,
+      statusText: 'Internal server error'
+    }),
+    {foo: BigInt(1234)}
+  );
+
+  const txt = await response.text();
+
+  expect(txt).toBe('');
+  expect(response.headers).toEqual(new Headers({'Content-Type': 'text/plain'}));
+  expect(response.status).toBe(500);
+  expect(response.statusText).toBe('Internal server error');
+});


### PR DESCRIPTION
This PR:

- fixes the `response.body` not readable of `ResponseError` returned by `withDecoder` combinator cloning the already consumed `Response`
- provide a helper function `cloneResponse`  

resolves #360 
