### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ import * as D from 'io-ts/Decoder';
 import {Decoder, toDecoder} from '@contactlab/appy/combinators/decoder';
 
 export const fromIots = <A>(d: D.Decoder<unknown, A>): Decoder<A> =>
-  toDecoder(d.decode, e => new Error(D.draw(e))
+  toDecoder(d.decode, e => new Error(D.draw(e)))
 ```
 
 ## About `fetch()` compatibility


### PR DESCRIPTION
Just a missing closing parentheses I catched while trying the latest version.
