### PR TITLE
Fix `request()` non-`Err` errors

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,9 +11,11 @@ const config: Config.InitialOptions = {
   coverageReporters: ['text'],
   globals: {
     'ts-jest': {
-      diagnostics: true
+      diagnostics: true,
+      isolatedModules: true
     }
   },
+  maxWorkers: '50%',
   moduleFileExtensions: ['js', 'json', 'node', 'ts'],
   preset: 'ts-jest',
   roots: ['<rootDir>/test/'],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "check": "tsc",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "pretest": "npm run lint && npm run check",
-    "test": "jest",
+    "test": "jest --runInBand",
     "prebuild": "rm -rf ./dist",
     "build": "tsc -p ./tsconfig.build.json && tsc -p ./tsconfig.build-es6.json",
     "postbuild": "ts-node scripts/prepare-dist",

--- a/src/request.ts
+++ b/src/request.ts
@@ -111,24 +111,21 @@ export const request: Req<string> = input => () => {
   const reqInput = normalizeReqInput(input);
 
   return fetch(...reqInput)
-    .then(
-      async response => {
-        if (!response.ok) {
-          throw toResponseError(
+    .then(async response => {
+      if (!response.ok) {
+        return E.left(
+          toResponseError(
             new Error(`Request responded with status code ${response.status}`),
             response
-          );
-        }
-
-        const data = await response.text();
-
-        return E.right({response, data});
-      },
-      e => {
-        throw toRequestError(e, reqInput);
+          )
+        );
       }
-    )
-    .catch(e => E.left(e));
+
+      const data = await response.text();
+
+      return E.right({response, data});
+    })
+    .catch(e => E.left(toRequestError(e, reqInput)));
 };
 
 /**


### PR DESCRIPTION
This PR:

- moves the `toRequestError` transformation in the `.catch()` block of `fetch()` execution in order to catch any possible thrown error and always return a `TaskEither.Left<Err>`.
- disables `ts-jest` type-checking and run test serially to enhance performance.

resolves #557
