### PR TITLE
Make non textual requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [5.1.0](https://github.com/contactlab/appy/releases/tag/5.1.0)
+
+**New Feature:**
+
+- Make non-textual requests (#665)
+
+**Dependencies:**
+
+- [Security] Bump json5 from 1.0.1 to 1.0.2 (#656)
+
 ## [5.0.0](https://github.com/contactlab/appy/releases/tag/5.0.0)
 
 **Breaking:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,16 @@ nav_order: 2
 
 # Changelog
 
+## [5.1.0](https://github.com/contactlab/appy/releases/tag/5.1.0)
+
+**New Feature:**
+
+- Make non-textual requests (#665)
+
+**Dependencies:**
+
+- [Security] Bump json5 from 1.0.1 to 1.0.2 (#656)
+
 ## [5.0.0](https://github.com/contactlab/appy/releases/tag/5.0.0)
 
 **Breaking:**

--- a/docs/modules/combinators/abort.ts.md
+++ b/docs/modules/combinators/abort.ts.md
@@ -77,7 +77,7 @@ users().then((result) => {
 **Signature**
 
 ```ts
-export declare function withCancel<A>(controller: AbortController): (req: Req<A>) => Req<A>
+export declare const withCancel: (controller: AbortController) => Combinator
 ```
 
 Added in v3.1.0
@@ -105,7 +105,7 @@ users().then((result) => {
 **Signature**
 
 ```ts
-export declare function withTimeout<A>(millis: number): (req: Req<A>) => Req<A>
+export declare const withTimeout: (millis: number) => <A>(req: Req<A>) => Req<A>
 ```
 
 Added in v3.1.0

--- a/docs/modules/combinators/body.ts.md
+++ b/docs/modules/combinators/body.ts.md
@@ -45,7 +45,7 @@ Sets the provided `body` (automatically converted to string when JSON) on `Req` 
 **Signature**
 
 ```ts
-export declare function withBody<A>(body: unknown): (req: Req<A>) => Req<A>
+export declare const withBody: (body: unknown) => Combinator
 ```
 
 Added in v3.0.0

--- a/docs/modules/combinators/decoder.ts.md
+++ b/docs/modules/combinators/decoder.ts.md
@@ -63,7 +63,7 @@ It automatically sets "JSON" request header's
 **Signature**
 
 ```ts
-export declare function withDecoder<A, B>(decoder: Decoder<B>): (req: Req<A>) => Req<B>
+export declare const withDecoder: <B>(decoder: Decoder<B>) => <A>(req: Req<A>) => Req<B>
 ```
 
 Added in v3.0.0
@@ -77,7 +77,7 @@ Converts a `GenericDecoder<L, A>` into a `Decoder<A>`.
 **Signature**
 
 ```ts
-export declare function toDecoder<L, A>(dec: GenericDecoder<L, A>, onLeft: (e: L) => Error): Decoder<A>
+export declare const toDecoder: <L, A>(dec: GenericDecoder<L, A>, onLeft: (e: L) => Error) => Decoder<A>
 ```
 
 Added in v3.0.0

--- a/docs/modules/combinators/headers.ts.md
+++ b/docs/modules/combinators/headers.ts.md
@@ -42,7 +42,7 @@ Merges provided `Headers` with `Req` ones and returns the updated `Req`.
 **Signature**
 
 ```ts
-export declare function withHeaders<A>(headers: HeadersInit): (req: Req<A>) => Req<A>
+export declare const withHeaders: (headers: HeadersInit) => Combinator
 ```
 
 Added in v3.0.0

--- a/docs/modules/combinators/method.ts.md
+++ b/docs/modules/combinators/method.ts.md
@@ -42,7 +42,7 @@ Sets provided method on `Req` and returns the updated `Req`.
 **Signature**
 
 ```ts
-export declare function withMethod<A>(method: string): (req: Req<A>) => Req<A>
+export declare const withMethod: (method: string) => Combinator
 ```
 
 Added in v4.0.0

--- a/docs/modules/combinators/url-params.ts.md
+++ b/docs/modules/combinators/url-params.ts.md
@@ -56,7 +56,7 @@ Adds provided url search parameters (as `Record<string, string>`) to `Req`'s inp
 **Signature**
 
 ```ts
-export declare function withUrlParams<A>(params: Params): (req: Req<A>) => Req<A>
+export declare const withUrlParams: (params: Params) => Combinator
 ```
 
 Added in v3.0.0

--- a/docs/modules/request.ts.md
+++ b/docs/modules/request.ts.md
@@ -23,6 +23,7 @@ Added in v4.0.0
   - [toRequestError](#torequesterror)
   - [toResponseError](#toresponseerror)
 - [Request](#request)
+  - [Combinator (type alias)](#combinator-type-alias)
   - [Req (interface)](#req-interface)
   - [ReqInput (type alias)](#reqinput-type-alias)
   - [RequestInfoInit (type alias)](#requestinfoinit-type-alias)
@@ -88,7 +89,7 @@ Creates a `RequestError` object.
 **Signature**
 
 ```ts
-export declare function toRequestError(error: Error, input: RequestInfoInit): RequestError
+export declare const toRequestError: (error: Error, input: RequestInfoInit) => RequestError
 ```
 
 Added in v4.0.0
@@ -100,12 +101,24 @@ Creates a `ResponseError` object.
 **Signature**
 
 ```ts
-export declare function toResponseError(error: Error, response: Response): ResponseError
+export declare const toResponseError: (error: Error, response: Response) => ResponseError
 ```
 
 Added in v4.0.0
 
 # Request
+
+## Combinator (type alias)
+
+A combinator is a function to transform/operate on a `Req`.
+
+**Signature**
+
+```ts
+export type Combinator = <A>(req: Req<A>) => Req<A>
+```
+
+Added in v5.1.0
 
 ## Req (interface)
 
@@ -152,7 +165,7 @@ Normalizes the input of a `Req` to a `RequestInfoInit` tuple even when only a si
 **Signature**
 
 ```ts
-export declare function normalizeReqInput(input: ReqInput): RequestInfoInit
+export declare const normalizeReqInput: (input: ReqInput) => RequestInfoInit
 ```
 
 Added in v4.0.0

--- a/docs/modules/request.ts.md
+++ b/docs/modules/request.ts.md
@@ -31,6 +31,7 @@ Added in v4.0.0
   - [Resp (interface)](#resp-interface)
 - [creators](#creators)
   - [request](#request)
+  - [requestAs](#requestas)
 
 ---
 
@@ -185,13 +186,13 @@ Example:
 
 ```ts
 import { request } from '@contactlab/appy'
-import { fold } from 'fp-ts/Either'
+import { match } from 'fp-ts/Either'
 
 // Default method is GET like original `fetch()`
 const users = request('https://reqres.in/api/users')
 
 users().then(
-  fold(
+  match(
     (err) => console.error(err),
     (data) => console.log(data)
   )
@@ -205,3 +206,36 @@ export declare const request: Req<string>
 ```
 
 Added in v4.0.0
+
+## requestAs
+
+Return a `Req` which will be executed using `fetch()` under the hood.
+
+The `data` in the returned `Resp` object is of the type specified in the `type` parameter which is one of [supported `Request` methods](https://developer.mozilla.org/en-US/docs/Web/API/Response#instance_methods).
+
+Example:
+
+```ts
+import { requestAs } from '@contactlab/appy'
+import { match } from 'fp-ts/Either'
+
+// Default method is GET like original `fetch()`
+const users = requestAs('json')('https://reqres.in/api/users')
+
+users().then(
+  match(
+    (err) => console.error(err),
+    (data) => console.log(data)
+  )
+)
+```
+
+**Signature**
+
+```ts
+export declare const requestAs: <K extends 'arrayBuffer' | 'blob' | 'formData' | 'json' | 'text'>(
+  type: K
+) => Req<BodyTypeData<K>>
+```
+
+Added in v5.1.0

--- a/docs/modules/response.ts.md
+++ b/docs/modules/response.ts.md
@@ -30,7 +30,7 @@ Clones a `Response` object with the provided content as body.
 **Signature**
 
 ```ts
-export declare function cloneResponse<A>(from: Response, content: A): Response
+export declare const cloneResponse: <A>(from: Response, content: A) => Response
 ```
 
 Added in v4.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@contactlab/appy",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@contactlab/appy",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/appy",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A functional wrapper around Fetch API",
   "main": "./index.js",
   "module": "./_es6/index.js",

--- a/src/combinators/decoder.ts
+++ b/src/combinators/decoder.ts
@@ -9,7 +9,7 @@ import {parse} from 'fp-ts/Json';
 import {ReaderEither, mapLeft} from 'fp-ts/ReaderEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
 import {pipe} from 'fp-ts/function';
-import {Err, Req, Resp, toResponseError} from '../request';
+import {type Err, type Req, type Resp, toResponseError} from '../request';
 import {cloneResponse} from '../response';
 import {withHeaders} from './headers';
 
@@ -39,10 +39,9 @@ export interface Decoder<A> extends GenericDecoder<Error, A> {}
  * @category combinators
  * @since 3.0.0
  */
-export function withDecoder<A, B>(
-  decoder: Decoder<B>
-): (req: Req<A>) => Req<B> {
-  return req =>
+export const withDecoder =
+  <B>(decoder: Decoder<B>) =>
+  <A>(req: Req<A>): Req<B> =>
     pipe(
       req,
       withHeaders({Accept: 'application/json'}),
@@ -60,7 +59,6 @@ export function withDecoder<A, B>(
         )
       )
     );
-}
 
 /**
  * Converts a `GenericDecoder<L, A>` into a `Decoder<A>`.
@@ -68,14 +66,12 @@ export function withDecoder<A, B>(
  * @category helpers
  * @since 3.0.0
  */
-export function toDecoder<L, A>(
+export const toDecoder = <L, A>(
   dec: GenericDecoder<L, A>,
   onLeft: (e: L) => Error
-): Decoder<A> {
-  return pipe(dec, mapLeft(onLeft));
-}
+): Decoder<A> => pipe(dec, mapLeft(onLeft));
 
-function parseResponse<A>({data}: Resp<A>): E.Either<Error, unknown> {
+const parseResponse = <A>({data}: Resp<A>): E.Either<Error, unknown> => {
   if (typeof data === 'object') {
     return E.right(data);
   }
@@ -84,4 +80,4 @@ function parseResponse<A>({data}: Resp<A>): E.Either<Error, unknown> {
   const prepared = asString.length === 0 ? '{}' : asString;
 
   return pipe(parse(prepared), E.mapLeft(E.toError));
-}
+};

--- a/src/combinators/headers.ts
+++ b/src/combinators/headers.ts
@@ -21,7 +21,7 @@ import {getMonoid} from 'fp-ts/Record';
 import {last} from 'fp-ts/Semigroup';
 import * as TU from 'fp-ts/Tuple';
 import {pipe} from 'fp-ts/function';
-import {Req, normalizeReqInput} from '../request';
+import {type Combinator, normalizeReqInput} from '../request';
 
 type Hs = Record<string, string>;
 
@@ -33,16 +33,15 @@ const RML = getMonoid(last<string>());
  * @category combinators
  * @since 3.0.0
  */
-export function withHeaders<A>(headers: HeadersInit): (req: Req<A>) => Req<A> {
-  return RTE.local(input =>
+export const withHeaders = (headers: HeadersInit): Combinator =>
+  RTE.local(input =>
     pipe(
       normalizeReqInput(input),
       TU.mapSnd(init => merge(init, headers))
     )
   );
-}
 
-function merge(init: RequestInit, h: HeadersInit): RequestInit {
+const merge = (init: RequestInit, h: HeadersInit): RequestInit => {
   // The "weird" `concat` is due to the mix of the contravariant nature of `Reader`
   // and the function composition at the base of "combinators".
   // Because combinators are applied from right to left, the merging has to be "reversed".
@@ -52,13 +51,12 @@ function merge(init: RequestInit, h: HeadersInit): RequestInit {
     typeof init.headers === 'undefined' ? toRecord(h) : concat(h, init.headers);
 
   return {...init, headers};
-}
+};
 
-function concat(a: HeadersInit, b: HeadersInit): Hs {
-  return RML.concat(toRecord(a), toRecord(b));
-}
+const concat = (a: HeadersInit, b: HeadersInit): Hs =>
+  RML.concat(toRecord(a), toRecord(b));
 
-function toRecord(h: HeadersInit): Hs {
+const toRecord = (h: HeadersInit): Hs => {
   if (Array.isArray(h)) {
     return h.reduce((acc, [k, v]) => ({...acc, [k]: v}), {});
   }
@@ -72,4 +70,4 @@ function toRecord(h: HeadersInit): Hs {
   }
 
   return h;
-}
+};

--- a/src/combinators/method.ts
+++ b/src/combinators/method.ts
@@ -19,7 +19,7 @@
 import * as RTE from 'fp-ts/ReaderTaskEither';
 import * as TU from 'fp-ts/Tuple';
 import {pipe} from 'fp-ts/function';
-import {Req, normalizeReqInput} from '../request';
+import {type Combinator, normalizeReqInput} from '../request';
 
 /**
  * Sets provided method on `Req` and returns the updated `Req`.
@@ -27,8 +27,8 @@ import {Req, normalizeReqInput} from '../request';
  * @category combinators
  * @since 4.0.0
  */
-export function withMethod<A>(method: string): (req: Req<A>) => Req<A> {
-  return RTE.local(input =>
+export const withMethod = (method: string): Combinator =>
+  RTE.local(input =>
     pipe(
       normalizeReqInput(input),
       // The "weird" MERGING is due to the mix of the contravariant nature of `Reader`
@@ -39,4 +39,3 @@ export function withMethod<A>(method: string): (req: Req<A>) => Req<A> {
       TU.mapSnd(init => ({method, ...init}))
     )
   );
-}

--- a/src/request.ts
+++ b/src/request.ts
@@ -41,6 +41,14 @@ export type ReqInput = RequestInfo | RequestInfoInit;
 export type RequestInfoInit = [RequestInfo, RequestInit];
 
 /**
+ * A combinator is a function to transform/operate on a `Req`.
+ *
+ * @category Request
+ * @since 5.1.0
+ */
+export type Combinator = <A>(req: Req<A>) => Req<A>;
+
+/**
  * `Resp<A>` is an object that carries the original `Response` from a `fetch()` call and the actual retrieved `data` (of type `A`).
  *
  * @category Response
@@ -178,12 +186,10 @@ export const request: Req<string> = requestAs('text');
  * @category Error
  * @since 4.0.0
  */
-export function toRequestError(
+export const toRequestError = (
   error: Error,
   input: RequestInfoInit
-): RequestError {
-  return {type: 'RequestError', error, input};
-}
+): RequestError => ({type: 'RequestError', error, input});
 
 /**
  * Creates a `ResponseError` object.
@@ -191,12 +197,10 @@ export function toRequestError(
  * @category Error
  * @since 4.0.0
  */
-export function toResponseError(
+export const toResponseError = (
   error: Error,
   response: Response
-): ResponseError {
-  return {type: 'ResponseError', response, error};
-}
+): ResponseError => ({type: 'ResponseError', response, error});
 
 /**
  * Normalizes the input of a `Req` to a `RequestInfoInit` tuple even when only a single `RequestInfo` is provided.
@@ -204,6 +208,5 @@ export function toResponseError(
  * @category Request
  * @since 4.0.0
  */
-export function normalizeReqInput(input: ReqInput): RequestInfoInit {
-  return Array.isArray(input) ? input : [input, {}];
-}
+export const normalizeReqInput = (input: ReqInput): RequestInfoInit =>
+  Array.isArray(input) ? input : [input, {}];

--- a/src/response.ts
+++ b/src/response.ts
@@ -13,7 +13,7 @@
  * @category helpers
  * @since 4.0.1
  */
-export function cloneResponse<A>(from: Response, content: A): Response {
+export const cloneResponse = <A>(from: Response, content: A): Response => {
   let body: BodyInit | null;
 
   try {
@@ -28,4 +28,4 @@ export function cloneResponse<A>(from: Response, content: A): Response {
     status: from.status,
     statusText: from.statusText
   });
-}
+};

--- a/test/decoder.spec.ts
+++ b/test/decoder.spec.ts
@@ -3,7 +3,7 @@ import {right, left} from 'fp-ts/Either';
 import * as RTE from 'fp-ts/ReaderTaskEither';
 import {pipe} from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
-import {Decoder, toDecoder, withDecoder} from '../src/combinators/decoder';
+import {type Decoder, toDecoder, withDecoder} from '../src/combinators/decoder';
 import {withHeaders} from '../src/combinators/headers';
 import * as appy from '../src/index';
 


### PR DESCRIPTION
This PR:

- adds a `requestAs()` function that let final users to choose which type of data will be returned in the response's body;
- converts all functions to arrow functions.

resolves #665 
