### PR TITLE
Drop Node.js v14

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -18,7 +18,7 @@ jobs:
     # --- Execute the job with 3 different versions of Node
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x]
 
     # --- Job tasks
     steps:


### PR DESCRIPTION
This PR:

- drops Node.js v14 (because it reached EOL) from CI matrix