### PR TITLE
[DEV] Bump typescript from 4.1.2 to 5.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
         "fp-ts": "^2.8.0",
         "husky": "^8.0.0",
         "io-ts": "^2.2.13",
-        "jest": "^29.0.0",
-        "jest-environment-jsdom": "^29.0.0",
+        "jest": "^29.6.1",
+        "jest-environment-jsdom": "^29.6.1",
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.0",
-        "ts-jest": "^29.0.0",
+        "ts-jest": "^29.1.1",
         "ts-node": "^10.0.0",
-        "typescript": "^4.1.2"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">= 16.0",
@@ -9876,16 +9876,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -17587,9 +17587,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "pretty-quick": "^3.1.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.0.0",
-    "typescript": "^4.1.2"
+    "typescript": "^5.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,10 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.0.0",
     "typescript": "^5.1.6"
+  },
+  "overrides": {
+    "eslint-config-contactlab": {
+      "typescript": "$typescript"
+    }
   }
 }


### PR DESCRIPTION
This PR upgrades `typescript` to v5.1.6