### PR TITLE
Add request input to `Resp` and `ResponseError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ interface ResponseError {
   type: 'ResponseError';
   error: Error;
   response: Response;
+  input?: RequestInfoInit;
 }
 ```
 
@@ -177,7 +178,7 @@ import * as D from 'io-ts/Decoder';
 import {Decoder, toDecoder} from '@contactlab/appy/combinators/decoder';
 
 export const fromIots = <A>(d: D.Decoder<unknown, A>): Decoder<A> =>
-  toDecoder(d.decode, e => new Error(D.draw(e)))
+  toDecoder(d.decode, e => new Error(D.draw(e)));
 ```
 
 ## About `fetch()` compatibility

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@ interface ResponseError {
   type: 'ResponseError';
   error: Error;
   response: Response;
+  input?: RequestInfoInit;
 }
 ```
 
@@ -182,7 +183,7 @@ import * as D from 'io-ts/Decoder';
 import {Decoder, toDecoder} from '@contactlab/appy/combinators/decoder';
 
 export const fromIots = <A>(d: D.Decoder<unknown, A>): Decoder<A> =>
-  toDecoder(d.decode, e => new Error(D.draw(e)))
+  toDecoder(d.decode, e => new Error(D.draw(e)));
 ```
 
 ## About `fetch()` compatibility

--- a/docs/modules/request.ts.md
+++ b/docs/modules/request.ts.md
@@ -77,6 +77,7 @@ export interface ResponseError {
   type: 'ResponseError'
   error: Error
   response: Response
+  input?: RequestInfoInit
 }
 ```
 
@@ -101,7 +102,11 @@ Creates a `ResponseError` object.
 **Signature**
 
 ```ts
-export declare const toResponseError: (error: Error, response: Response) => ResponseError
+export declare const toResponseError: (
+  error: Error,
+  response: Response,
+  input?: RequestInfoInit | undefined
+) => ResponseError
 ```
 
 Added in v4.0.0
@@ -182,6 +187,7 @@ Added in v4.0.0
 export interface Resp<A> {
   response: Response
   data: A
+  input?: RequestInfoInit
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -64,11 +64,6 @@
     "ts-node": "^10.0.0",
     "typescript": "^5.1.6"
   },
-  "overrides": {
-    "eslint-config-contactlab": {
-      "typescript": "$typescript"
-    }
-  },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write"
   }

--- a/src/combinators/decoder.ts
+++ b/src/combinators/decoder.ts
@@ -52,7 +52,11 @@ export const withDecoder =
             E.chain(decoder),
             E.bimap(
               (e): Err =>
-                toResponseError(e, cloneResponse(resp.response, resp.data)),
+                toResponseError(
+                  e,
+                  cloneResponse(resp.response, resp.data),
+                  resp.input
+                ),
               data => ({...resp, data})
             )
           )

--- a/test/abort.spec.ts
+++ b/test/abort.spec.ts
@@ -4,6 +4,8 @@ import {pipe} from 'fp-ts/function';
 import {withCancel, withTimeout} from '../src/combinators/abort';
 import * as appy from '../src/index';
 
+type Resp = appy.Resp<string>;
+
 afterEach(() => {
   fetchMock.reset();
 });
@@ -19,13 +21,13 @@ test('withCancel() should set signal on `Req` and make request abortable', async
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    left({
-      type: 'RequestError',
-      error: new AbortError(),
-      input: ['http://localhost/api/resources', {signal: controller.signal}]
-    })
-  );
+  const err: appy.Err = {
+    type: 'RequestError',
+    error: new AbortError(),
+    input: ['http://localhost/api/resources', {signal: controller.signal}]
+  };
+
+  expect(result).toEqual(left(err));
 });
 
 test('withCancel() should set signal on `Req` and make request abortable - multiple calls', async () => {
@@ -44,13 +46,13 @@ test('withCancel() should set signal on `Req` and make request abortable - multi
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    left({
-      type: 'RequestError',
-      error: new AbortError(),
-      input: ['http://localhost/api/resources', {signal: controller2.signal}]
-    })
-  );
+  const err: appy.Err = {
+    type: 'RequestError',
+    error: new AbortError(),
+    input: ['http://localhost/api/resources', {signal: controller2.signal}]
+  };
+
+  expect(result).toEqual(left(err));
 });
 
 test('withCancel() should merge provided signal with `Req` one - but `Req` wins', async () => {
@@ -68,13 +70,13 @@ test('withCancel() should merge provided signal with `Req` one - but `Req` wins'
     {signal: controller2.signal}
   ])();
 
-  expect(result).toEqual(
-    left({
-      type: 'RequestError',
-      error: new AbortError(),
-      input: ['http://localhost/api/resources', {signal: controller2.signal}]
-    })
-  );
+  const err: appy.Err = {
+    type: 'RequestError',
+    error: new AbortError(),
+    input: ['http://localhost/api/resources', {signal: controller2.signal}]
+  };
+
+  expect(result).toEqual(left(err));
 });
 
 test('withTimeout() should succeed if we get a response within provided milliseconds', async () => {
@@ -89,7 +91,16 @@ test('withTimeout() should succeed if we get a response within provided millisec
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp = {
+    response,
+    data: 'a list of resources',
+    input: [
+      'http://localhost/api/resources',
+      {signal: new AbortController().signal}
+    ]
+  };
+
+  expect(result).toEqual(right(resp));
 });
 
 test('withTimeout() should succeed if we get a response within provided milliseconds - multiple calls', async () => {
@@ -104,7 +115,16 @@ test('withTimeout() should succeed if we get a response within provided millisec
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp = {
+    response,
+    data: 'a list of resources',
+    input: [
+      'http://localhost/api/resources',
+      {signal: new AbortController().signal}
+    ]
+  };
+
+  expect(result).toEqual(right(resp));
 });
 
 test('withTimeout() should fail if we do not get a response within provided milliseconds', async () => {
@@ -114,16 +134,16 @@ test('withTimeout() should fail if we do not get a response within provided mill
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    left({
-      type: 'RequestError',
-      error: new AbortError(),
-      input: [
-        'http://localhost/api/resources',
-        {signal: new AbortController().signal}
-      ]
-    })
-  );
+  const err: appy.Err = {
+    type: 'RequestError',
+    error: new AbortError(),
+    input: [
+      'http://localhost/api/resources',
+      {signal: new AbortController().signal}
+    ]
+  };
+
+  expect(result).toEqual(left(err));
 });
 
 test('withTimeout() should fail if we do not get a response within provided milliseconds - multiple calls', async () => {
@@ -133,16 +153,16 @@ test('withTimeout() should fail if we do not get a response within provided mill
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    left({
-      type: 'RequestError',
-      error: new AbortError(),
-      input: [
-        'http://localhost/api/resources',
-        {signal: new AbortController().signal}
-      ]
-    })
-  );
+  const err: appy.Err = {
+    type: 'RequestError',
+    error: new AbortError(),
+    input: [
+      'http://localhost/api/resources',
+      {signal: new AbortController().signal}
+    ]
+  };
+
+  expect(result).toEqual(left(err));
 });
 
 // --- Helpers

--- a/test/decoder.spec.ts
+++ b/test/decoder.spec.ts
@@ -19,12 +19,16 @@ test('withDecoder() should decodes `Resp` with provided decoder', async () => {
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    right({
-      response,
-      data: {id: 1234, name: 'foo bar'}
-    })
-  );
+  const resp: appy.Resp<Payload> = {
+    response,
+    data: {id: 1234, name: 'foo bar'},
+    input: [
+      'http://localhost/api/resources',
+      {headers: {Accept: 'application/json'}, method: 'GET'}
+    ]
+  };
+
+  expect(result).toEqual(right(resp));
 
   expect(fetchMock.lastOptions()).toEqual({
     headers: {Accept: 'application/json'},
@@ -63,12 +67,16 @@ test('withDecoder() should decodes `Resp` with provided decoder - response data 
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    right({
-      response,
-      data: {}
-    })
-  );
+  const resp: appy.Resp<unknown> = {
+    response,
+    data: {},
+    input: [
+      'http://localhost/api/resources',
+      {headers: {Accept: 'application/json'}, method: 'GET'}
+    ]
+  };
+
+  expect(result).toEqual(right(resp));
 });
 
 test('withDecoder() should decodes `Resp` with provided decoder - response data is an object', async () => {
@@ -86,12 +94,12 @@ test('withDecoder() should decodes `Resp` with provided decoder - response data 
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    right({
-      response,
-      data: {id: 5678, name: 'THIS IS BAAAZ!'}
-    })
-  );
+  const resp: appy.Resp<Payload> = {
+    response,
+    data: {id: 5678, name: 'THIS IS BAAAZ!'}
+  };
+
+  expect(result).toEqual(right(resp));
 });
 
 test('withDecoder() should decodes `Resp` with provided decoder - response data stringified', async () => {
@@ -109,12 +117,12 @@ test('withDecoder() should decodes `Resp` with provided decoder - response data 
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    right({
-      response,
-      data: 12345678
-    })
-  );
+  const resp: appy.Resp<number> = {
+    response,
+    data: 12345678
+  };
+
+  expect(result).toEqual(right(resp));
 });
 
 test('withDecoder() should fail if response data cannot be parsed', async () => {
@@ -150,13 +158,17 @@ test('withDecoder() should fail if decoding fails', async () => {
 
   const result = await request('http://localhost/api/resources')();
 
-  expect(result).toEqual(
-    left({
-      type: 'ResponseError',
-      error: new Error('decoding failed'),
-      response: new Response(content) // <-- cloned
-    })
-  );
+  const err: appy.Err = {
+    type: 'ResponseError',
+    error: new Error('decoding failed'),
+    response: new Response(content), // <-- cloned
+    input: [
+      'http://localhost/api/resources',
+      {headers: {Accept: 'application/json'}, method: 'GET'}
+    ]
+  };
+
+  expect(result).toEqual(left(err));
 
   // --- ResponseError `response` content is readable
   const txt = await (result as any).left.response.text();

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,6 +2,8 @@ import fetchMock from 'fetch-mock';
 import {right} from 'fp-ts/Either';
 import * as appy from '../src/index';
 
+type Resp = appy.Resp<string>;
+
 afterEach(() => {
   fetchMock.reset();
 });
@@ -13,7 +15,13 @@ test('get() should run a GET request', async () => {
 
   const r = await appy.get('http://localhost/api/resources')();
 
-  expect(r).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp = {
+    response,
+    data: 'a list of resources',
+    input: ['http://localhost/api/resources', {method: 'GET'}]
+  };
+
+  expect(r).toEqual(right(resp));
 
   expect(fetchMock.called('http://localhost/api/resources', 'GET')).toBe(true);
 });
@@ -28,7 +36,13 @@ test('post() should run a POST request', async () => {
     {body: 'foo'}
   ])();
 
-  expect(r).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp = {
+    response,
+    data: 'a list of resources',
+    input: ['http://localhost/api/resources', {method: 'POST', body: 'foo'}]
+  };
+
+  expect(r).toEqual(right(resp));
 
   expect(fetchMock.called('http://localhost/api/resources', 'POST')).toBe(true);
 });
@@ -40,7 +54,13 @@ test('put() should run a PUT request', async () => {
 
   const r = await appy.put(['http://localhost/api/resources', {body: 'foo'}])();
 
-  expect(r).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp = {
+    response,
+    data: 'a list of resources',
+    input: ['http://localhost/api/resources', {method: 'PUT', body: 'foo'}]
+  };
+
+  expect(r).toEqual(right(resp));
 
   expect(fetchMock.called('http://localhost/api/resources', 'PUT')).toBe(true);
 });
@@ -55,7 +75,13 @@ test('patch() should run a PATCH request', async () => {
     {body: 'foo'}
   ])();
 
-  expect(r).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp = {
+    response,
+    data: 'a list of resources',
+    input: ['http://localhost/api/resources', {method: 'PATCH', body: 'foo'}]
+  };
+
+  expect(r).toEqual(right(resp));
 
   expect(fetchMock.called('http://localhost/api/resources', 'PATCH')).toBe(
     true
@@ -69,7 +95,13 @@ test('del() should run a DELETE request', async () => {
 
   const r = await appy.del('http://localhost/api/resources')();
 
-  expect(r).toEqual(right({response, data: ''}));
+  const resp: Resp = {
+    response,
+    data: '',
+    input: ['http://localhost/api/resources', {method: 'DELETE'}]
+  };
+
+  expect(r).toEqual(right(resp));
 
   expect(fetchMock.called('http://localhost/api/resources', 'DELETE')).toBe(
     true

--- a/test/request.spec.ts
+++ b/test/request.spec.ts
@@ -1,7 +1,9 @@
 import fetchMock from 'fetch-mock';
 import {right, left, isLeft} from 'fp-ts/Either';
 import {
+  type Err,
   type RequestInfoInit,
+  type Resp,
   request,
   requestAs,
   toRequestError,
@@ -42,29 +44,29 @@ test('requestAs() should return a left `RequestError` when request fails', async
 
   const r1 = await requestAsBlob('http://localhost/api/resources')();
 
-  expect(r1).toEqual(
-    left({
-      type: 'RequestError',
-      error,
-      input: ['http://localhost/api/resources', {}]
-    })
-  );
+  const err1: Err = {
+    type: 'RequestError',
+    error,
+    input: ['http://localhost/api/resources', {}]
+  };
+
+  expect(r1).toEqual(left(err1));
 
   const r2 = await requestAsBlob([
     'http://localhost/api/resources',
     {method: 'GET', headers: {'X-Some-Header': 'some value'}}
   ])();
 
-  expect(r2).toEqual(
-    left({
-      type: 'RequestError',
-      error,
-      input: [
-        'http://localhost/api/resources',
-        {method: 'GET', headers: {'X-Some-Header': 'some value'}}
-      ]
-    })
-  );
+  const err2: Err = {
+    type: 'RequestError',
+    error,
+    input: [
+      'http://localhost/api/resources',
+      {method: 'GET', headers: {'X-Some-Header': 'some value'}}
+    ]
+  };
+
+  expect(r2).toEqual(left(err2));
 });
 
 test('requestAs() should return a left `ResponseError` when response status is not ok', async () => {
@@ -76,13 +78,14 @@ test('requestAs() should return a left `ResponseError` when response status is n
 
   const r = await requestAsBlob('http://localhost/api/resources')();
 
-  expect(r).toEqual(
-    left({
-      type: 'ResponseError',
-      response,
-      error: new Error(`Request responded with status code 503`)
-    })
-  );
+  const err: Err = {
+    type: 'ResponseError',
+    response,
+    error: new Error(`Request responded with status code 503`),
+    input: ['http://localhost/api/resources', {}]
+  };
+
+  expect(r).toEqual(left(err));
 });
 
 test('request() should return a right `Resp<string>` - default GET', async () => {
@@ -95,7 +98,13 @@ test('request() should return a right `Resp<string>` - default GET', async () =>
 
   const r = await request('http://localhost/api/resources')();
 
-  expect(r).toEqual(right({response, data: 'a list of resources'}));
+  const resp: Resp<string> = {
+    response,
+    data: 'a list of resources',
+    input: ['http://localhost/api/resources', {}]
+  };
+
+  expect(r).toEqual(right(resp));
 });
 
 test('request() should return a right `Resp<string>` - with POST', async () => {
@@ -108,7 +117,13 @@ test('request() should return a right `Resp<string>` - with POST', async () => {
     {method: 'POST', body: ''}
   ])();
 
-  expect(r).toEqual(right({response, data: 'POST - a list of resources'}));
+  const resp: Resp<string> = {
+    response,
+    data: 'POST - a list of resources',
+    input: ['http://localhost/api/post-resources', {method: 'POST', body: ''}]
+  };
+
+  expect(r).toEqual(right(resp));
 });
 
 test('request() should return a left `RequestError` when request fails', async () => {
@@ -118,29 +133,29 @@ test('request() should return a left `RequestError` when request fails', async (
 
   const r1 = await request('http://localhost/api/resources')();
 
-  expect(r1).toEqual(
-    left({
-      type: 'RequestError',
-      error,
-      input: ['http://localhost/api/resources', {}]
-    })
-  );
+  const err1: Err = {
+    type: 'RequestError',
+    error,
+    input: ['http://localhost/api/resources', {}]
+  };
+
+  expect(r1).toEqual(left(err1));
 
   const r2 = await request([
     'http://localhost/api/resources',
     {method: 'GET', headers: {'X-Some-Header': 'some value'}}
   ])();
 
-  expect(r2).toEqual(
-    left({
-      type: 'RequestError',
-      error,
-      input: [
-        'http://localhost/api/resources',
-        {method: 'GET', headers: {'X-Some-Header': 'some value'}}
-      ]
-    })
-  );
+  const err2: Err = {
+    type: 'RequestError',
+    error,
+    input: [
+      'http://localhost/api/resources',
+      {method: 'GET', headers: {'X-Some-Header': 'some value'}}
+    ]
+  };
+
+  expect(r2).toEqual(left(err2));
 });
 
 test('request() should return a left `ResponseError` when response status is not ok', async () => {
@@ -152,33 +167,48 @@ test('request() should return a left `ResponseError` when response status is not
 
   const r = await request('http://localhost/api/resources')();
 
-  expect(r).toEqual(
-    left({
-      type: 'ResponseError',
-      response,
-      error: new Error(`Request responded with status code 503`)
-    })
-  );
+  const err: Err = {
+    type: 'ResponseError',
+    response,
+    error: new Error(`Request responded with status code 503`),
+    input: ['http://localhost/api/resources', {}]
+  };
+
+  expect(r).toEqual(left(err));
 });
 
 test('toRequestError() should return a RequestError', () => {
   const error = new TypeError('something bad happened');
   const input: RequestInfoInit = ['http://localhost/my/api', {method: 'GET'}];
 
-  expect(toRequestError(error, input)).toEqual({
+  const err: Err = {
     type: 'RequestError',
     error,
     input
-  });
+  };
+
+  expect(toRequestError(error, input)).toEqual(err);
 });
 
 test('toResponseError() should return a ResponseError', () => {
   const response = new Response('bad', {status: 500});
   const badStatus = new Error('Request responded with status 500');
+  const input: RequestInfoInit = ['http://localhost/my/api', {method: 'GET'}];
 
-  expect(toResponseError(badStatus, response)).toEqual({
+  const err1: Err = {
     type: 'ResponseError',
     error: badStatus,
     response
-  });
+  };
+
+  expect(toResponseError(badStatus, response)).toEqual(err1);
+
+  const err2 = {
+    type: 'ResponseError',
+    error: badStatus,
+    response,
+    input
+  };
+
+  expect(toResponseError(badStatus, response, input)).toEqual(err2);
 });


### PR DESCRIPTION
This PR:

- adds the request's input to `Resp` and `ResponseError` interfaces in order to be able to read it also in responses (even with errors)

At the moment, the new `input` field is optional in order to be retro-compatible.

resolves #743 
